### PR TITLE
Migrate lodash to ^4.0.0

### DIFF
--- a/cmds/upgrade.js
+++ b/cmds/upgrade.js
@@ -1,7 +1,6 @@
 var awm = require('../lib/awm');
 var _ = require('lodash');
 var AdmZip = require('adm-zip');
-var plist = require('plist');
 var fs = require('fs-extra');
 var async = require('async');
 var exec = require('child_process').exec;
@@ -32,8 +31,8 @@ module.exports = function(program) {
               else{
 
                 var outdated = awm.getOutdated(function(packages){
-                  var outdatedBundles = _.pluck(packages, 'bundle');
-                  if(!_.contains(outdatedBundles, bundleID))
+                  var outdatedBundles = _.map(packages, 'bundle');
+                  if(!_.includes(outdatedBundles, bundleID))
                     console.info('Workflow is at it\'s lastest version');
                   else{
                     awm.downloadFile(selectedWF, function(err, filePath){

--- a/lib/awm.js
+++ b/lib/awm.js
@@ -264,11 +264,21 @@ module.exports = {
 
 function splitArrayValues(jsManifest){
 
+  var trim = _.flow(_.toString, _.trim);
+
   _(jsManifest.manifest.workflow).each(function(wf){
-    if(wf.categories) wf.categories = _.map(wf.categories.split('|||'), function(str){ return str.trim(); });
-    if(wf.osx) wf.osx = _.map(wf.osx.split('|||'), function(str){ return str.trim(); });
-    if(wf.tags) wf.tags = _.map(wf.tags.split('|||'), function(str){ return str.trim(); });
-    if(wf.webservices) wf.webservices = _.map(wf.webservices.split('|||'), function(str){ return str.trim(); });
+    if (wf.categories) {
+      wf.categories = _.map(wf.categories.split('|||'), trim);
+    }
+    if(wf.osx) {
+      wf.osx = _.map(wf.osx.split('|||'), trim);
+    }
+    if(wf.tags) {
+      wf.tags = _.map(wf.tags.split('|||'), trim);
+    }
+    if(wf.webservices) {
+      wf.webservices = _.map(wf.webservices.split('|||'), trim);
+    }
   });
 
   return jsManifest;

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "colors": "~0.6.2",
     "commander": "~2.3.0",
     "fs-extra": "~0.9.1",
-    "lodash": "~2.4.1",
-    "plist": "~1.0.0",
+    "lodash": "^4.0.0",
+    "plist": "^2.0.0",
     "progress": "~1.1.6",
     "request": "~2.36.0",
     "xml2js": "~0.4.4"


### PR DESCRIPTION
I figure more than a few Alfred users would probably love for `awm` to get ready for the year 2017. So why not get rid of a few `npm` warnings as a warm-up and get familiar with the code base along the way? ❤️ 

# Dusting lodash

This PR is to migrate the `lodash` dependency from the deprecated `2.4.x` to the latest `4.0.0` version.

As lodash v2.4.x has been deprecated for ages, installing or updating `awm` would make `npm` print the following warning:

```
npm WARN deprecated lodash-node@2.4.1: This package is discontinued. Use lodash@^4.0.0.
```

For first-time users, this makes for a poor out-of-the-box experience; for developers, I deem this an ongoing distraction.

# Compatibility checks

To check for incompatibilities, I ran the `lodash-migrate` package prior to bumping the version number to ^4.0.0. This revealed the following compatibility issues to v2.4.x, which are all fixed in this PR:

- lodash v3.0.0 has introduced the `_.trim` method, allowing for making `awm`’s array splitting code a bit simpler. (Not an actual issue.)

- lodash v3.0.0 has renamed the `_.contains` method to `_.includes`; the remaining `_.contains` alias was subsequently removed in v4.0.0.

- lodash v4.0.0 has removed the `_.pluck` method because it doubles the newly introduced iteratee short-cut semantics, e. g. `_.map(packages, 'bundle')`.

# Fixing indirect dependencies

This PR also bumps the `plist` dependency to `^2.0.0` because its older version had an indirect dependency on an outdated lodash release.

Considering the stable API track record of either module within major releases, I opted for the `^` modifier in both cases.

# See also

- [Package lodash-migrate on npmjs.com](https://www.npmjs.com/package/lodash-migrate)
- [lodash v3.0.0 » Notable Changes](https://github.com/lodash/lodash/wiki/Changelog/23cf804c63cb1dafb3f47bd99cc7c3d96d42d102#notable-changes-1)
- [lodash v4.0.0 » Compatibility Warnings](https://github.com/lodash/lodash/wiki/Changelog/23cf804c63cb1dafb3f47bd99cc7c3d96d42d102#compatibility-warnings)
