### PR TITLE
Make npm stop complaining about the `license` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,7 @@
     "type": "git",
     "url": "https://github.com/jonathanwiesel/awm"
   },
-  "license": {
-    "type": "MIT",
-    "url": "http://jonathanwiesel.mit-license.org/"
-  },
+  "license": "MIT",
   "bugs": "https://github.com/jonathanwiesel/awm/issues",
   "dependencies": {
     "adm-zip": "^0.4.4",


### PR DESCRIPTION
This PR is driven solely from a technical point of view; THIS IS NOT UNDERSTOOD TO CONSTITUTE A LEGAL SERVICE.

Somewhere along npm’s timeline, the documentation of the `package.json` format was updated to clarify that the `license` field requires a simple String, not a complex object, as a value. The string also needs to be equal to one of the entries on the SPDX license list (found at https://spdx.org/licenses).

However, in its present form, it is not a String but a complex object (a `type`/`url` tuple). This causes NPM to print a warning at install/update time:

> `WARN awm@0.0.4 license should be a valid SPDX license expression`

In order to make `awm` play well with `npm` again, this PR suggests to replace the `license` value with a simple String that says `MIT`.

This will remove Jonathan’s personalized MIT URL from the `license` entry. However, that personalized URL still remains in the _License_ section of `Readme.md`, and is left unchanged there.

See also:

- https://docs.npmjs.com/files/package.json#license
- https://spdx.org/licenses
- https://github.com/npm/npm/issues/8918