### PR TITLE
Lose outdated `node-uuid` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "~2.4.1",
     "plist": "~1.0.0",
     "progress": "~1.1.6",
-    "request": "~2.36.0",
+    "request": "^2.79.0",
     "xml2js": "~0.4.4"
   },
   "engines": {


### PR DESCRIPTION
`npm install` keeps telling me:

> `npm WARN deprecated node-uuid@1.4.7: use uuid module instead`

With `awm` depending on `node-uuid` only indirectly, and only through the `request` package, it is probably sufficient to bump the latter to `^2.79.0` in order to get rid of `node-uuid`.

Apart from that, staying on top of any networking code [should be considered good practice anyway](https://github.com/request/request/issues?q=is%3Aissue%20security); I figure this justifies a `^` modifier so `awm` users continue to receive the latest 2.x updates of the `request` package from now on.

This is the last PR in my little trilogy of “shut-up-npm” PRs. I hope it helps a little to make the out-of-the-box experience a tiny bit friendlier.

By the way, thanks @jonathanwiesel for giving us `awm`! 🌻 
